### PR TITLE
Invisible clickable area

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,9 @@
 import { LitElement, css, html } from 'lit'
 import { customElement, property } from 'lit/decorators.js'
 
+const ratioUp = Math.sqrt(80 ** 2 + 80 ** 2) / 80
+const ratioDown = 1 / ratioUp
+
 /**
  * A github corner.
  */
@@ -33,6 +36,23 @@ export class GitHubCorners extends LitElement {
       .github-corner .octo-arm {
         animation: octocat-wave 560ms ease-in-out;
       }
+    }
+
+    .github-corner-wrapper {
+      position:absolute;
+      top:0;
+      border:0;
+      width:80px;
+      height:80px;
+      overflow:hidden;
+    }
+
+    .github-corner {
+      position:relative;
+      display: block;
+      width: 80px;
+      height: 80px;
+      overflow: hidden;
     }
   `
 
@@ -84,30 +104,40 @@ export class GitHubCorners extends LitElement {
   @property({ type: String })
     position = 'right'
 
-  getPositionStyles(position: String): string {
+  getLinkTransform(position: String): string {
     if (position === 'left')
-      return 'left:0;transform: scale(-1, 1);'
+      return `transform-origin:center; transform: rotate(-45deg) scale(${-ratioUp}, ${ratioUp}) translate(0, -50%);)`
 
     else
-      return 'right:0;'
+      return `transform-origin:center; transform: rotate(45deg) scale(${ratioUp}) translate(0, -50%);`
+  }
+
+  getSvgTransform(): string {
+    return `transform: scale(${ratioDown}) rotate(-45deg) translate(-50%, 50%);`
   }
 
   render() {
-    const styles = `position: absolute;top: 0;border: 0;${this.getPositionStyles(this.position)}`
     return html`
-      <a href="${this.url || `https://github.com/${this.repo}`}" class="github-corner" aria-label="${this.label}"
-        target="${this.blank ? '_blank' : null}" style="${styles}">
-        <svg width="80" height="80" viewBox="0 0 250 250" fill="${this.reverse ? this.color : this.fill}"
-          color="${this.reverse ? this.fill : this.color}" aria-hidden="true">
-          <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
-          <path
-            d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"
-            fill="currentColor" style="transform-origin: 130px 106px" class="octo-arm"></path>
-          <path
-            d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z"
-            fill="currentColor" class="octo-body"></path>
-        </svg>
-      </a>
+      <div class="github-corner-wrapper" style="${this.position === 'left' ? 'left:0;' : 'right:0;'}">
+        <a
+          href="${this.url || `https://github.com/${this.repo}`}"
+          class="github-corner"
+          aria-label="${this.label}"
+          target="${this.blank ? '_blank' : null}"
+          style="${this.getLinkTransform(this.position)}"
+        >
+          <svg width="80" height="80" viewBox="0 0 250 250" fill="${this.reverse ? this.color : this.fill}"
+            color="${this.reverse ? this.fill : this.color}" aria-hidden="true" style="${this.getSvgTransform()}">
+            <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+            <path
+              d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"
+              fill="currentColor" style="transform-origin: 130px 106px" class="octo-arm"></path>
+            <path
+              d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z"
+              fill="currentColor" class="octo-body"></path>
+          </svg>
+        </a>
+      </div>
     `
   }
 }


### PR DESCRIPTION
Hi,

I've added some css transforms to remove the invisible clickable area.
This area is especially on mobile devices confusing for users.

The demo works fine for me.

However the build is failing locally on my side (I guess due to some wrong setup):
Issues with
node_modules/@types => https://github.com/microsoft/TypeScript/issues/51567
And
file:///[...]/wc-github-corners/scripts/gen-docs.ts:8
delete manifest.modules[0].exports;

Best Regards
H0rn0chse